### PR TITLE
add tests for contest tournament feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,18 @@
             <artifactId>jfreechart</artifactId>
             <version>1.5.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 
 
     </dependencies>

--- a/src/main/java/bot/listener/ContestTimerHandler.java
+++ b/src/main/java/bot/listener/ContestTimerHandler.java
@@ -36,7 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ContestTimerHandler extends ListenerAdapter {
-    private final Map<String, ScheduledExecutorService> activeTimers = new HashMap<>();
+    final Map<String, ScheduledExecutorService> activeTimers = new HashMap<>();
     private final Logger logger = LoggerFactory.getLogger(ContestTimerHandler.class);
     private static final String BASE_URL = "https://codeforces.com/api/";
     private static final Gson gson = new Gson();
@@ -82,10 +82,12 @@ public class ContestTimerHandler extends ListenerAdapter {
                 .map(Button::asDisabled)
                 .toList();
 
-        // Edit the message to disable the buttons
-        message.editMessageComponents(
-                Collections.singletonList(ActionRow.of(updatedButtons))
-        ).queue();
+        // Ensure the list of buttons is not empty before creating the ActionRow
+        if (!updatedButtons.isEmpty()) {
+            message.editMessageComponents(
+                    Collections.singletonList(ActionRow.of(updatedButtons))
+            ).queue();
+        }
 
 
         // Example: "2 hours 25 minutes"

--- a/src/test/java/bot/infrastructure/CodeforcesAPIImplTest.java
+++ b/src/test/java/bot/infrastructure/CodeforcesAPIImplTest.java
@@ -1,0 +1,175 @@
+package bot.infrastructure;
+
+import bot.api.ApiCaller;
+import bot.domain.user.Rating;
+import bot.util.EmbedBuilderUtil;
+import net.dv8tion.jda.api.EmbedBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class CodeforcesAPIImplTest {
+
+    @Mock
+    private ApiCaller apiCaller;
+
+    private CodeforcesAPIImpl codeforcesAPI;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        codeforcesAPI = new CodeforcesAPIImpl(apiCaller);
+    }
+
+    @Test
+    void getUserInfo() throws IOException {
+        String mockResponse = "{\"status\":\"OK\",\"result\":[{\"handle\":\"tourist\",\"rating\":3779,\"maxRating\":3779,\"rank\":\"legendary grandmaster\",\"maxRank\":\"legendary grandmaster\"}]}";
+        int rating = 3779;
+        int maxRating = 3779;
+        String rank = "legendary grandmaster";
+        String maxRank = "legendary grandmaster";
+        int contribution = 0;
+
+        when(apiCaller.makeApiCall(anyString())).thenReturn(mockResponse);
+
+        EmbedBuilder embed = codeforcesAPI.getUserInfo("tourist");
+
+        assertNotNull(embed);
+        assertEquals("`tourist`'s Codeforces Info", embed.build().getTitle());
+        assertEquals(String.valueOf(rating), Objects.requireNonNull(embed.build().getFields().getFirst()).getValue());
+        assertEquals(String.valueOf(maxRating), Objects.requireNonNull(embed.build().getFields().get(1)).getValue());
+        assertEquals(rank, Objects.requireNonNull(embed.build().getFields().get(2)).getValue());
+        assertEquals(maxRank, Objects.requireNonNull(embed.build().getFields().get(3)).getValue());
+        assertEquals(String.valueOf(contribution), Objects.requireNonNull(embed.build().getFields().get(4)).getValue());
+    }
+
+    @Test
+    void getUpcomingContests() throws IOException {
+        String mockResponse = "{\"status\":\"OK\",\"result\":[{\"id\":1234,\"name\":\"Codeforces Round #123\",\"type\":\"CF\",\"phase\":\"BEFORE\",\"frozen\":false,\"durationSeconds\":7200,\"startTimeSeconds\":1609459200,\"relativeTimeSeconds\":-86400}]}";
+        when(apiCaller.makeApiCall(anyString())).thenReturn(mockResponse);
+
+        EmbedBuilder embed = codeforcesAPI.getUpcomingContests();
+
+        assertNotNull(embed);
+        assertEquals("Upcoming Contests", embed.build().getTitle());
+        assertEquals(Color.ORANGE, embed.build().getColor());
+        assertFalse(embed.build().getFields().isEmpty());
+        assertEquals("Codeforces Round #123 (ID: 1234)", embed.build().getFields().getFirst().getName());
+
+        System.out.println(embed.build().getFields().getFirst().getValue());
+        String value = Objects.requireNonNull(embed.build().getFields().getFirst().getValue());
+        List<String> lines = Arrays.asList(value.split("\n"));
+        assertEquals("Start Time: 01/01/2021 02:00:00", lines.getFirst());
+        assertEquals("Duration: 2 hours", lines.get(1));
+        assertEquals("Before start 1 days 0 hours 0 minutes", lines.get(2));
+    }
+
+    @Test
+    void getFinishedContests() throws IOException {
+        String mockResponse = "{\"status\":\"OK\",\"result\":[{\"id\":1234,\"name\":\"Codeforces Round #123\",\"type\":\"CF\",\"phase\":\"FINISHED\",\"frozen\":false,\"durationSeconds\":7200,\"startTimeSeconds\":1609459200,\"relativeTimeSeconds\":86400}]}";
+        when(apiCaller.makeApiCall(anyString())).thenReturn(mockResponse);
+
+        EmbedBuilder embed = codeforcesAPI.getFinishedContests();
+
+        assertNotNull(embed);
+        assertEquals("Finished Contests", embed.build().getTitle());
+        assertEquals(Color.GREEN, embed.build().getColor());
+        assertFalse(embed.build().getFields().isEmpty());
+        assertEquals("Codeforces Round #123 (ID: 1234)", embed.build().getFields().getFirst().getName());
+
+        String value = Objects.requireNonNull(embed.build().getFields().getFirst().getValue());
+        List<String> lines = Arrays.asList(value.split("\n"));
+        assertEquals("Start Time: 01/01/2021 02:00:00", lines.getFirst());
+        assertEquals("Duration: 2 hours", lines.get(1));
+        assertEquals("Finished 1 days 0 hours 0 minutes ago", lines.get(2));
+    }
+
+    @Test
+    void getStandingContestForUser() throws IOException {
+        String mockResponse = "{\"status\":\"OK\",\"result\":{\"contest\":{\"id\":1234,\"name\":\"Codeforces Round #123\",\"type\":\"CF\",\"phase\":\"FINISHED\",\"frozen\":false,\"durationSeconds\":7200,\"startTimeSeconds\":1609459200,\"relativeTimeSeconds\":86400},\"problems\":[{\"contestId\":1234,\"index\":\"A\",\"name\":\"Problem A\",\"type\":\"PROGRAMMING\",\"points\":500,\"rating\":800}],\"rows\":[{\"party\":{\"contestId\":1234,\"members\":[{\"handle\":\"tourist\"}]},\"rank\":1,\"points\":3000,\"penalty\":0,\"successfulHackCount\":0,\"unsuccessfulHackCount\":0,\"problemResults\":[{\"points\":500,\"rejectedAttemptCount\":0,\"type\":\"FINAL\",\"bestSubmissionTimeSeconds\":3600}]}]}}";
+        when(apiCaller.makeApiCall(anyString())).thenReturn(mockResponse);
+
+        EmbedBuilder embed = codeforcesAPI.getStandingContestForUser("tourist", 1234);
+
+        assertNotNull(embed);
+        assertTrue(Objects.requireNonNull(embed.build().getTitle()).contains("tourist"));
+        assertEquals("`tourist`'s Standing in Contest", embed.build().getTitle());
+        assertEquals(Color.cyan, embed.build().getColor());
+        assertFalse(embed.build().getFields().isEmpty());
+        assertEquals("Contest", embed.build().getFields().getFirst().getName());
+        assertTrue(Objects.requireNonNull(embed.build().getFields().getFirst().getValue()).contains("Codeforces Round #123"));
+        assertEquals("Start Time", embed.build().getFields().get(1).getName());
+        assertEquals("01/01/2021 02:00:00", embed.build().getFields().get(1).getValue());
+        assertEquals("Rank", embed.build().getFields().get(2).getName());
+        assertEquals("1", embed.build().getFields().get(2).getValue());
+        assertEquals("Solved", embed.build().getFields().get(3).getName());
+        assertEquals("1/1", embed.build().getFields().get(3).getValue());
+        assertEquals("Problem", embed.build().getFields().get(4).getName());
+        assertTrue(Objects.requireNonNull(embed.build().getFields().get(4).getValue()).contains("Problem A"));
+    }
+
+    @Test
+    void getRatingHistory() throws IOException {
+        String mockResponse = "{\"status\":\"OK\",\"result\":[{\"contestId\":1234,\"contestName\":\"Codeforces Round #123\",\"handle\":\"tourist\",\"rank\":1,\"ratingUpdateTimeSeconds\":1609459200,\"oldRating\":3779,\"newRating\":3780}]}";
+        when(apiCaller.makeApiCall(anyString())).thenReturn(mockResponse);
+
+        List<Rating> ratingHistory = codeforcesAPI.getRatingHistory("tourist");
+
+        assertNotNull(ratingHistory);
+        assertFalse(ratingHistory.isEmpty());
+        assertEquals(1234, ratingHistory.getFirst().getContestId());
+        assertEquals("tourist", ratingHistory.getFirst().getHandle());
+        assertEquals(1, ratingHistory.getFirst().getRank());
+        assertEquals(1609459200, ratingHistory.getFirst().getRatingUpdateTimeSeconds());
+        assertEquals(3779, ratingHistory.getFirst().getOldRating());
+        assertEquals(3780, ratingHistory.getFirst().getNewRating());
+
+        // Test for image generation
+        EmbedBuilder embed = EmbedBuilderUtil.buildRatingHistoryEmbed(ratingHistory, "tourist");
+        assertNotNull(embed);
+        assertTrue(Objects.requireNonNull(embed.build().getDescription()).contains("rating history graph"));
+        assertTrue(embed.build().getFields().stream().anyMatch(field -> Objects.equals(field.getName(), "Current Rating")));
+        assertTrue(embed.build().getFields().stream().anyMatch(field -> Objects.equals(field.getName(), "Max Rating")));
+        String imageUrl = Objects.requireNonNull(embed.build().getImage()).getUrl();
+        assertNotNull(imageUrl);
+        assertTrue(imageUrl.contains("attachment://rating_history_tourist.png"));
+
+        // Test for image deletion
+        String filePath = imageUrl.replace("attachment://", "");
+        File file = new File(filePath);
+        assertTrue(file.exists());
+        assertTrue(file.delete());
+        assertFalse(file.exists());
+    }
+
+    @Test
+    void getRandomProblem() throws IOException {
+        String mockResponse = "{\"status\":\"OK\",\"result\":{\"problems\":[{\"contestId\":1234,\"index\":\"A\",\"name\":\"Problem A\",\"type\":\"PROGRAMMING\",\"points\":500,\"rating\":800,\"tags\":[\"implementation\"]}]}}";
+        when(apiCaller.makeApiCall(anyString())).thenReturn(mockResponse);
+
+        EmbedBuilder embed = codeforcesAPI.getRandomProblem(Collections.singletonList("implementation"), 800, 1000);
+
+        assertNotNull(embed);
+        assertEquals("A. Problem A", embed.build().getTitle());
+        assertEquals("https://codeforces.com/contest/1234/problem/A", embed.build().getUrl());
+        assertEquals(Color.GREEN, embed.build().getColor());
+        assertFalse(embed.build().getFields().isEmpty());
+        assertEquals("Rating", embed.build().getFields().getFirst().getName());
+        assertEquals("800", embed.build().getFields().getFirst().getValue());
+        assertEquals("Tags", embed.build().getFields().get(1).getName());
+        assertEquals("implementation", embed.build().getFields().get(1).getValue());
+    }
+}

--- a/src/test/java/bot/infrastructure/CodeforcesAPIImplTest.java
+++ b/src/test/java/bot/infrastructure/CodeforcesAPIImplTest.java
@@ -1,0 +1,123 @@
+package bot.infrastructure;
+
+import bot.api.ApiCaller;
+import bot.api.ApiResponse;
+import bot.domain.contest.Contest;
+import bot.domain.contest.Party;
+import bot.domain.contest.Problem;
+import bot.domain.user.Submission;
+import com.google.gson.Gson;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CodeforcesAPIImplTest {
+
+    @Mock
+    private ApiCaller apiCaller;
+
+    @Mock
+    private SlashCommandInteractionEvent event;
+
+    private CodeforcesAPIImpl codeforcesAPI;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        codeforcesAPI = new CodeforcesAPIImpl(apiCaller);
+    }
+
+    @Test
+    void testGetRandomContestValidInput() throws IOException {
+        // Mock the contest list response
+        List<Contest> contests = Arrays.asList(
+                new Contest(2018, "Codeforces Round 975 (Div. 1)", "CF", "FINISHED", false, 9000, 1727444100, 1293035),
+                new Contest(2019, "Codeforces Round 975 (Div. 2)", "CF", "FINISHED", false, 9000, 1727444100, 1293035)
+        );
+        ApiResponse<List<Contest>> contestApiResponse = new ApiResponse<>("OK", contests);
+        String contestJsonResponse = new Gson().toJson(contestApiResponse);
+        when(apiCaller.makeApiCall(anyString())).thenReturn(contestJsonResponse);
+
+        // Mock the user status response
+        Problem problem1 = new Problem();
+        Party author = new Party(2018, List.of(new Party.Member("_AhmedMohamed_")), "CONTESTANT", false, 1692887700);
+        Submission.Verdict verdict = Submission.Verdict.OK;
+        Submission.Testset testset = Submission.Testset.TESTS;
+
+        List<Submission> submissions = Arrays.asList(
+                new Submission(220287033, 342, 1692895752, 8052, problem1, author, "C++20 (GCC 11-64)", verdict, testset, 17, 15, 0, null),
+                new Submission(220263495, 54, 1692893677, 5977, problem1, author, "C++20 (GCC 11-64)", verdict, testset, 19, 77, 20889600, null)
+        );
+        ApiResponse<List<Submission>> submissionApiResponse = new ApiResponse<>("OK", submissions);
+        String submissionJsonResponse = new Gson().toJson(submissionApiResponse);
+        when(apiCaller.makeApiCall(contains("user.status"))).thenReturn(submissionJsonResponse);
+
+        // Verify the response
+        ZonedDateTime fixedTime = ZonedDateTime.parse("2024-10-12T16:01:00+03:00[EET]"); // Fixed time for testing
+        try (MockedStatic<ZonedDateTime> mockedTime = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockedTime.when(ZonedDateTime::now).thenReturn(fixedTime);
+
+            // Call the method
+            List<String> usernames = Arrays.asList("user1", "user2");
+            ZonedDateTime startTime = ZonedDateTime.now();
+            ZonedDateTime userTime = ZonedDateTime.now();
+            EmbedBuilder contest = codeforcesAPI.getRandomContest(event, usernames, "div2", startTime, userTime);
+
+            // Verify the response
+            assertNotNull(contest);
+            assertEquals("[Codeforces Round 975 (Div. 2)](https://codeforces.com/contest/2019)", contest.getFields().get(0).getValue());
+            assertEquals("2019", contest.getFields().get(1).getValue());
+            assertEquals("CF", contest.getFields().get(2).getValue());
+            assertEquals("October 12, 2024, 4:01 PM EEST", contest.getFields().get(3).getValue());
+            assertEquals("2 hours 30 minutes", contest.getFields().get(4).getValue());
+        }
+    }
+
+    @Test
+    void getRandomContest_noSuitableContests() throws IOException {
+        // Mock the contest list response
+        List<Contest> contests = Arrays.asList(
+                new Contest(2018, "Codeforces Round 975 (Div. 1)", "CF", "FINISHED", false, 9000, 1727444100, 1293035),
+                new Contest(2019, "Codeforces Round 975 (Div. 2)", "CF", "FINISHED", false, 9000, 1727444100, 1293035)
+        );
+        ApiResponse<List<Contest>> contestApiResponse = new ApiResponse<>("OK", contests);
+        String contestJsonResponse = new Gson().toJson(contestApiResponse);
+        when(apiCaller.makeApiCall(anyString())).thenReturn(contestJsonResponse);
+
+        // Mock the user status response
+        Problem problem1 = new Problem();
+        Party author = new Party(2018, List.of(new Party.Member("_AhmedMohamed_")), "CONTESTANT", false, 1692887700);
+        Submission.Verdict verdict = Submission.Verdict.OK;
+        Submission.Testset testset = Submission.Testset.TESTS;
+        List<Submission> submissions = Arrays.asList(
+                new Submission(220287033, 2018, 1692895752, 8052, problem1, author, "C++20 (GCC 11-64)", verdict, testset, 17, 15, 0, null),
+                new Submission(220263495, 2019, 1692893677, 5977, problem1, author, "C++20 (GCC 11-64)", verdict, testset, 19, 77, 20889600, null)
+        );
+        ApiResponse<List<Submission>> submissionApiResponse = new ApiResponse<>("OK", submissions);
+        String submissionJsonResponse = new Gson().toJson(submissionApiResponse);
+        when(apiCaller.makeApiCall(contains("user.status"))).thenReturn(submissionJsonResponse);
+
+        // Call the method
+        List<String> usernames = Arrays.asList("user1", "user2");
+        ZonedDateTime startTime = ZonedDateTime.now();
+        ZonedDateTime userTime = ZonedDateTime.now();
+
+        // Verify the exception
+        IOException exception = assertThrows(IOException.class, () -> {
+            codeforcesAPI.getRandomContest(event, usernames, "div2", startTime, userTime);
+        });
+        assertEquals("No suitable contests found.", exception.getMessage());
+    }
+}

--- a/src/test/java/bot/infrastructure/RandomContestCommandTest.java
+++ b/src/test/java/bot/infrastructure/RandomContestCommandTest.java
@@ -23,7 +23,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-class CodeforcesAPIImplTest {
+class RandomContestCommandTest {
 
     @Mock
     private ApiCaller apiCaller;

--- a/src/test/java/bot/listener/ContestTimerHandlerTest.java
+++ b/src/test/java/bot/listener/ContestTimerHandlerTest.java
@@ -1,0 +1,121 @@
+package bot.listener;
+
+import bot.api.ApiCaller;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ContestTimerHandlerTest {
+
+    @Mock
+    private ApiCaller apiCallerMock;
+
+    @Mock
+    private ButtonInteractionEvent eventMock;
+
+    @Mock
+    private Message messageMock;
+
+    private ContestTimerHandler contestTimerHandler;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        contestTimerHandler = new ContestTimerHandler(apiCallerMock);
+    }
+
+    @Test
+    void testTimerAddedAfterConfirmButton() {
+        // Arrange
+        String contestId = "1234";
+        String contestName = "[Test Contest]";
+        String startTimeStr = "May 1, 2023, 10:00 AM +03:00";
+        String durationStr = "2 hours 25 minutes";
+        String participantsStr = "`user1`, `user2`";
+
+        // Mock the event and message
+        MessageChannelUnion channelUnionMock = mock(MessageChannelUnion.class);
+        MessageCreateAction messageCreateActionMock = mock(MessageCreateAction.class);
+        ReplyCallbackAction replyCallbackActionMock = mock(ReplyCallbackAction.class);
+
+        when(channelUnionMock.sendMessageEmbeds(any(MessageEmbed.class), any(MessageEmbed[].class))).thenReturn(messageCreateActionMock);
+        when(eventMock.getChannel()).thenReturn(channelUnionMock);
+        when(eventMock.reply(anyString())).thenReturn(replyCallbackActionMock);
+        when(replyCallbackActionMock.setEphemeral(anyBoolean())).thenReturn(replyCallbackActionMock);
+
+        // Mock the embed
+        when(messageMock.getEmbeds()).thenReturn(List.of(createMockEmbed(startTimeStr, durationStr, participantsStr, contestId, contestName)));
+        when(eventMock.getMessage()).thenReturn(messageMock);
+        when(eventMock.getComponentId()).thenReturn("confirm_contest");
+
+        // Act
+        contestTimerHandler.onButtonInteraction(eventMock);
+
+        // Assert
+        assertTrue(contestTimerHandler.activeTimers.containsKey(contestId), "The timer should be added to activeTimers");
+        ScheduledExecutorService scheduler = contestTimerHandler.activeTimers.get(contestId);
+        assertNotNull(scheduler, "The timer scheduler should not be null");
+
+        // Clean up the scheduler
+        scheduler.shutdownNow();
+    }
+
+
+    @Test
+    void testContestTournamentResult() throws IOException {
+        List<String> participants = Arrays.asList("user1", "user2");
+        String contestId = "1234";
+        String contestName = "Test Contest";
+
+        // Mock the API call
+        when(apiCallerMock.makeApiCall(anyString())).thenReturn(createMockApiResponse());
+
+        // Call the method
+        EmbedBuilder result = contestTimerHandler.contestTournamentResult(participants, contestId, contestName);
+
+        // Assert the result
+        assertNotNull(result);
+        assertEquals("Contest Results: Test Contest", result.build().getTitle());
+        assertEquals("[`user1`](https://codeforces.com/profile/user1)\t:trophy: **Champion!**", result.build().getFields().get(0).getValue());
+        assertEquals("1", result.build().getFields().get(1).getValue());
+        assertEquals("1", result.build().getFields().get(2).getValue());
+        assertEquals("0", result.build().getFields().get(3).getValue());
+        assertEquals("[`user2`](https://codeforces.com/profile/user2)\t:medal: **Top 3, impressive!**", result.build().getFields().get(4).getValue());
+        assertEquals("2", result.build().getFields().get(5).getValue());
+        assertEquals("1", result.build().getFields().get(6).getValue());
+        assertEquals("1", result.build().getFields().get(7).getValue());
+    }
+
+    private MessageEmbed createMockEmbed(String startTimeStr, String durationStr, String participantsStr, String contestId, String contestName) {
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setTitle("Contest Details");
+        embedBuilder.addField("Virtual Start Time", startTimeStr, false);
+        embedBuilder.addField("Duration", durationStr, false);
+        embedBuilder.addField("Participants", participantsStr, false);
+        embedBuilder.addField("Contest ID", contestId, false);
+        embedBuilder.addField("Contest Name", contestName, false);
+        return embedBuilder.build();
+    }
+
+    private String createMockApiResponse() {
+        return "{\"status\":\"OK\",\"result\":{\"contest\":{\"id\":1234,\"name\":\"Test Contest\"},\"problems\":[],\"rows\":[{\"party\":{\"members\":[{\"handle\":\"user1\"}]},\"rank\":1,\"points\":100,\"problemResults\":[{\"points\":100,\"rejectedAttemptCount\":0}]},{\"party\":{\"members\":[{\"handle\":\"user2\"}]},\"rank\":2,\"points\":50,\"problemResults\":[{\"points\":50,\"rejectedAttemptCount\":1}]}]}}";
+    }
+}


### PR DESCRIPTION
- Unit tests for the contest-tournament feature were added.
- Unit tests for the existing features were added.
- Used Mockito to mock API calls and ensured correct responses were handled.
- Verified EmbedBuilder content, colors, and formatting are accurate across test cases.

Tests can be run using this command: 
``` bash
mvn test
```

![image](https://github.com/user-attachments/assets/81f3daa8-f24f-45a6-a849-1c7ef435a7a3)